### PR TITLE
readme QA : download node 0 Unknown,node download url modify

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ FAQ
 
 Maybe you associated ".js" file to another app, not JScript engine. To fix, see [here](http://www.winhelponline.com/articles/230/1/Error-There-is-no-script-engine-for-file-extension-when-running-js-files.html)
 
+### Q. Node.exe download faild caused '0 Unknown'
+
+Maybe you modify fget.js  `var xhr = WScript.createObject('Msxml2.XMLHttp')` -> `var xhr = WScript.createObject('Msxml2.ServerXMLHttp')`
+
 LICENSE
 -------
 (The MIT License)

--- a/nvmw.bat
+++ b/nvmw.bat
@@ -132,9 +132,9 @@ if %NODE_TYPE% == iojs (
   )
 ) else (
   if %ARCH% == x32 (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/node.exe
+    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x86/node.exe
   ) else (
-    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/x64/node.exe
+    set NODE_EXE_URL=%NVMW_NODEJS_ORG_MIRROR%/%NODE_VERSION%/win-x64/node.exe
   )
 )
 


### PR DESCRIPTION
某些情况下.  使用Msxml2.XMLHttp 下载会报  0 Unknown 错误.  可以使用Msxml2.ServerXMLHttp替代. 所以只修改了. readme文件.    npm.taobao.org 里面连接地址修改导致不能下载到最新的node版本.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/nvmw/1)

<!-- Reviewable:end -->
